### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,3 +35,9 @@ jobs:
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph
         uses: advanced-security/maven-dependency-submission-action@v4
+          permissions:
+          contents: read
+          id-token: write
+          actions: read
+          security-events: write
+          dependencies: write


### PR DESCRIPTION
Potential fix for [https://github.com/gryphus-lab/piggymetrics/security/code-scanning/1](https://github.com/gryphus-lab/piggymetrics/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since this workflow only checks out code, sets up Java, builds with Maven, and optionally uploads a dependency graph, it does not require write access to repository contents. The minimal permission required is `contents: read`. This block should be added at the top level of the workflow (just after the `name:` field and before `on:`), so it applies to all jobs in the workflow. No changes to the steps or job definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
