### PR TITLE
Potential fix for code scanning alert no. 12: Disabled Spring CSRF protection

### DIFF
--- a/config/src/main/java/com/piggymetrics/config/SecurityConfig.java
+++ b/config/src/main/java/com/piggymetrics/config/SecurityConfig.java
@@ -12,7 +12,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable();
         http
                 .authorizeRequests()
                 .antMatchers("/actuator/**").permitAll()


### PR DESCRIPTION
Potential fix for [https://github.com/gryphus-lab/piggymetrics/security/code-scanning/12](https://github.com/gryphus-lab/piggymetrics/security/code-scanning/12)

To fix the problem, CSRF protection should not be disabled. The line `http.csrf().disable();` should be removed from the `configure` method. By default, Spring Security enables CSRF protection, so simply omitting the disabling call will restore the default, secure behavior. No additional imports or method changes are required. The rest of the security configuration can remain as is, unless there are endpoints (such as `/actuator/**`) that need to be accessed without CSRF protection; in that case, you can selectively disable CSRF for those endpoints, but that is not shown or required here.

**Steps:**
- In `config/src/main/java/com/piggymetrics/config/SecurityConfig.java`, remove the line `http.csrf().disable();` (line 15).
- No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
