### PR TITLE
Potential fix for code scanning alert no. 11: Disabled Spring CSRF protection

### DIFF
--- a/auth-service/src/main/java/com/piggymetrics/auth/config/WebSecurityConfig.java
+++ b/auth-service/src/main/java/com/piggymetrics/auth/config/WebSecurityConfig.java
@@ -23,9 +23,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         // @formatter:off
         http
-                .authorizeRequests().anyRequest().authenticated()
-                .and()
-                .csrf().disable();
+                .authorizeRequests().anyRequest().authenticated();
         // @formatter:on
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/gryphus-lab/piggymetrics/security/code-scanning/11](https://github.com/gryphus-lab/piggymetrics/security/code-scanning/11)

To fix the problem, CSRF protection should be enabled by removing the `.csrf().disable()` call from the Spring Security configuration. By default, Spring Security enables CSRF protection, so simply omitting the `.csrf().disable()` line will restore the default, secure behavior. This change should be made in the `configure(HttpSecurity http)` method in `auth-service/src/main/java/com/piggymetrics/auth/config/WebSecurityConfig.java`, specifically by removing or commenting out the `.csrf().disable()` call on line 28. No additional imports or method definitions are required, as CSRF protection is enabled by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
